### PR TITLE
chore: updated docs for v1.2.0 oracle node release

### DIFF
--- a/docs/commands/staker/set-config.md
+++ b/docs/commands/staker/set-config.md
@@ -37,7 +37,7 @@ Example:
 **Note**: _Make sure you input your alternate provider value as a value to alternateProvider flag
 
 ```
-$ ./razor setConfig --provider https://mainnet.skalenodes.com/v1/turbulent-unique-scheat --alternateProvider [ALTERNATE_PROVIDER] --gasmultiplier 1 --buffer 20 --wait 30 --gasprice 0 --logLevel debug --gasLimit 2 --gasLimitOverride 50000000 --rpcTimeout 10 --httpTimeout 10 --logFileMaxSize 200 --logFileMaxBackups 52 --logFileMaxAge 365
+$ ./razor setConfig --provider https://mainnet.skalenodes.com/v1/turbulent-unique-scheat --alternateProvider [ALTERNATE_PROVIDER] --gasmultiplier 1 --buffer 20 --wait 30 --gasprice 0 --logLevel debug --gasLimit 2 --gasLimitOverride 50000000 --rpcTimeout 10 --httpTimeout 10 --logFileMaxSize 200 --logFileMaxBackups 10 --logFileMaxAge 60
 ```
 
 Other than setting these parameters in the config, you can use different values of these parameters in different command. Just add the same flag to any command you want to use and the new config changes will appear for that command.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -45,7 +45,7 @@ docker network create razor_network
 2. Start razor-go container
 
 ```
-docker run -d -it --entrypoint /bin/sh --network=razor_network --name razor-go -v "$(echo $HOME)"/.razor:/root/.razor razornetwork/razor-go:v1.1.0-patch.1
+docker run -d -it --entrypoint /bin/sh --network=razor_network --name razor-go -v "$(echo $HOME)"/.razor:/root/.razor razornetwork/razor-go:v1.2.0
 ```
 
 > **_NOTE:_** we are leveraging docker bind-mounts to mount `.razor` directory so that we have a shared mount of `.razor` directory between the host and the container. The `.razor` directory holds keys to the addresses that we use in `razor-go`, along with logs and config. We do this to persist data in the host machine, otherwise you would lose your keys once you delete the container.

--- a/docs/mainnet/getting-started.md
+++ b/docs/mainnet/getting-started.md
@@ -14,7 +14,7 @@ Use this guide [here](../delegate.md) for more information about delegating your
 
 The docker image version is [1.2.0](https://hub.docker.com/layers/razornetwork/razor-go/v1.1.0-patch.1/images/sha256-4ae226fb3bcc1a3115a9f747ffd1d89be7fd0eb5e79474892bfaba9bd8d6e730?context=explore).
 
-The latest `razor-go` release on GitHub is [1.1.0-patch.1](https://github.com/razor-network/oracle-node/releases/tag/v1.1.0-patch.1).
+The latest `razor-go` release on GitHub is [1.2.0](https://github.com/razor-network/oracle-node/releases/tag/v1.2.0).
 
 The latest contracts npm package is [1.0.2](https://www.npmjs.com/package/@razor-network/contracts/v/1.0.2)
 

--- a/docs/mainnet/getting-started.md
+++ b/docs/mainnet/getting-started.md
@@ -12,7 +12,7 @@ Use this guide [here](../delegate.md) for more information about delegating your
 
 ## Technical Links
 
-The docker image version is [1.1.0-patch.1](https://hub.docker.com/layers/razornetwork/razor-go/v1.1.0-patch.1/images/sha256-4ae226fb3bcc1a3115a9f747ffd1d89be7fd0eb5e79474892bfaba9bd8d6e730?context=explore).
+The docker image version is [1.2.0](https://hub.docker.com/layers/razornetwork/razor-go/v1.1.0-patch.1/images/sha256-4ae226fb3bcc1a3115a9f747ffd1d89be7fd0eb5e79474892bfaba9bd8d6e730?context=explore).
 
 The latest `razor-go` release on GitHub is [1.1.0-patch.1](https://github.com/razor-network/oracle-node/releases/tag/v1.1.0-patch.1).
 

--- a/docs/stake/mainnet.md
+++ b/docs/stake/mainnet.md
@@ -84,7 +84,7 @@ There are a set of parameters that are configurable. These include:
 - Maximum age of log file: This is the maximum number of days to retain old log files.
 
 ```
-docker exec -it razor-go razor setConfig --provider https://mainnet.skalenodes.com/v1/turbulent-unique-scheat --gasmultiplier 1 --buffer 20 --wait 30 --gasprice 0 --logLevel debug --gasLimit 2 --gasLimitOverride 50000000 --rpcTimeout 10 --httpTimeout 10 --logFileMaxSize 200 --logFileMaxBackups 52 --logFileMaxAge 365
+docker exec -it razor-go razor setConfig --provider https://mainnet.skalenodes.com/v1/turbulent-unique-scheat --gasmultiplier 1 --buffer 20 --wait 30 --gasprice 0 --logLevel debug --gasLimit 2 --gasLimitOverride 50000000 --rpcTimeout 10 --httpTimeout 10 --logFileMaxSize 200 --logFileMaxBackups 10 --logFileMaxAge 60
 ```
 
 >**_NOTE:_**: _This will create `razor.yaml` with all necessary parameter at `$HOME/.razor` directory. We can view that via command:`cat $HOME/.razor/razor.yaml` ._

--- a/docs/stake/mainnet.md
+++ b/docs/stake/mainnet.md
@@ -42,9 +42,9 @@ It is recommended to run a **Oracle Node** using **Docker**. This is because you
 
 Docker: You can find more information about installing docker [here](https://docs.docker.com/engine/install/).
 
-Oracle-Node(github): You can download the Oracle-Node:1.1.0-patch.1 from [here](https://github.com/razor-network/oracle-node/releases/tag/v1.1.0-patch.1).
+Oracle-Node(github): You can download the Oracle-Node:1.2.0 from [here](https://github.com/razor-network/oracle-node/releases/tag/v1.2.0).
 
-You can download the docker image of Razor-go:v1.1.0-patch.1 from [here](https://hub.docker.com/layers/razornetwork/razor-go/v1.1.0-patch.1/images/sha256-4ae226fb3bcc1a3115a9f747ffd1d89be7fd0eb5e79474892bfaba9bd8d6e730?context=explore).
+You can download the docker image of Razor-go:v1.2.0 from [here](https://hub.docker.com/layers/razornetwork/razor-go/v1.1.0-patch.1/images/sha256-4ae226fb3bcc1a3115a9f747ffd1d89be7fd0eb5e79474892bfaba9bd8d6e730?context=explore).
 
 ### Run the Razor Network Docker Node {#run-the-razor-network-docker-node}
 
@@ -59,7 +59,7 @@ docker network create razor_network
 2. Start razor-go container
 
 ```
-docker run -d -it --entrypoint /bin/sh --network=razor_network --name razor-go -v "$(echo $HOME)"/.razor:/root/.razor razornetwork/razor-go:v1.1.0-patch.1
+docker run -d -it --entrypoint /bin/sh --network=razor_network --name razor-go -v "$(echo $HOME)"/.razor:/root/.razor razornetwork/razor-go:v1.2.0
 ```
 
 This spins up a razor-go docker image. You can find all the images on the [Razor Network dockerhub](https://hub.docker.com/u/razornetwork).
@@ -214,7 +214,7 @@ To update the razor-go node version
 2. Check your container is running via `docker ps`, you should get an output like:
     ```
     CONTAINER ID   IMAGE                                  COMMAND     CREATED         STATUS         PORTS     NAMES
-    5f0b7d99a71b   razornetwork/razor-go:v1.0.6           "/bin/sh"   3 weeks ago     Up 3 weeks               razor-go
+    5f0b7d99a71b   razornetwork/razor-go:v1.1.0-patch.1           "/bin/sh"   3 weeks ago     Up 3 weeks               razor-go
     ```
 3. Stop the existing container  
     `docker stop razor-go`
@@ -225,14 +225,14 @@ To update the razor-go node version
     docker run -d -it --entrypoint /bin/sh --network=razor_network --name razor-go -v "$(echo $HOME)"/.razor:/root/.razor razornetwork/razor-go:<version>
     ```
 
-    example: If latest version is `v1.1.0-patch.1` then the command would be:
+    example: If latest version is `v1.2.0` then the command would be:
     ```
-    docker run -d -it --entrypoint /bin/sh --network=razor_network --name razor-go -v "$(echo $HOME)"/.razor:/root/.razor razornetwork/razor-go:v1.1.0-patch.1
+    docker run -d -it --entrypoint /bin/sh --network=razor_network --name razor-go -v "$(echo $HOME)"/.razor:/root/.razor razornetwork/razor-go:v1.2.0
     ```
 6. Check your container is running `docker ps`, you should get an output like: 
     ```
     CONTAINER ID   IMAGE                          COMMAND     CREATED          STATUS          PORTS     NAMES
-    53ff3ce7c965   razornetwork/razor-go:v1.1.0-patch.1   "/bin/sh"   17 seconds ago   Up 16 seconds             razor-go
+    53ff3ce7c965   razornetwork/razor-go:v1.2.0   "/bin/sh"   17 seconds ago   Up 16 seconds             razor-go
     ```
 7. If you want to update your config file, you can run [SetConfig](https://docs.razor.to/docs/stake/mainnet#set-config) command
 

--- a/docs/stake/testnet.md
+++ b/docs/stake/testnet.md
@@ -87,7 +87,7 @@ There are a set of parameters that are configurable. These include:
 - Maximum age of log file: This is the maximum number of days to retain old log files.
 
 ```
-docker exec -it razor-go razor setConfig --provider https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar --gasmultiplier 1 --buffer 20 --wait 30 --gasprice 0 --logLevel debug --gasLimit 2 --rpcTimeout 10 --httpTimeout 10 --logFileMaxSize 200 --logFileMaxBackups 52 --logFileMaxAge 365
+docker exec -it razor-go razor setConfig --provider https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar --gasmultiplier 1 --buffer 20 --wait 30 --gasprice 0 --logLevel debug --gasLimit 2 --rpcTimeout 10 --httpTimeout 10 --logFileMaxSize 200 --logFileMaxBackups 10 --logFileMaxAge 60
 ```
 
 > **Note**: _This will create `razor.yaml` with all necessary parameter at `$HOME/.razor` directory. We can view that via command:`cat $HOME/.razor/razor.yaml` ._

--- a/docs/stake/testnet.md
+++ b/docs/stake/testnet.md
@@ -8,7 +8,7 @@ You will need some Skale Testnet Tokens to pay for transaction fees.
 You can get testnet ETH tokens from here:
 https://faucet.skale.network/
 
-- Skale Endpoint: https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar
+- Skale Endpoint: https://testnet.skalenodes.com/v1/juicy-low-small-testnet
 - Account: address which should receive the testnet tokens.
 
 In order to get started, you will also need some RAZORs on Skale Testnet chain. Drop a message in our [Discord server](https://discord.com/invite/Js4pBny2rw) for tokens.
@@ -21,11 +21,11 @@ In order to get started, you will also need some RAZORs on Skale Testnet chain. 
 
    | Particulars        | Value                                                                   |
    | ------------------ | ----------------------------------------------------------------------- |
-   | Network Name       | staging-aware-chief-gianfar                                             |
-   | New RPC URL        | https://staging-v3.skalenodes.com/v1/staging-aware-chief-gianfar        |
-   | Chain ID           | 1517929550                                                              |
+   | Network Name       | juicy-low-small-testnet                                             |
+   | New RPC URL        | https://testnet.skalenodes.com/v1/juicy-low-small-testnet        |
+   | Chain ID           | 0x561bf78b                                                              |
    | Currency Symbol    | ETH                                                                     |
-   | Block Explorer URL | https://staging-aware-chief-gianfar.explorer.staging-v3.skalenodes.com/ |
+   | Block Explorer URL | https://juicy-low-small-testnet.explorer.testnet.skalenodes.com/ |
 
    > **Note**: _You can also add network from https://staging.razorscan.io/ by clicking on "Connect wallet" and switching network to Skale._
 
@@ -47,7 +47,7 @@ Docker: You can find more information about installing docker [here](https://doc
 
 Oracle-Node(github): You can check the Razor-go:dev at [develop branch](https://github.com/razor-network/oracle-node/tree/develop).
 
-You can download the docker image of Razor-go:dev - `ab83868` from [here]https://hub.docker.com/layers/razornetwork/razor-go/ab83868/images/sha256-c3d9efc9cbb56fb30544d4eba7c264c7fdb176f3cb8b012e4873883c18394601?context=explore.
+You can download the docker image of Razor-go:dev - `7f77a9f` from [here]https://hub.docker.com/layers/razornetwork/razor-go/7f77a9f/images/sha256-99409212071104eab59fe5c35d5968ddeb16d9a034d4e4d77de5b95e5dadeb5f?context=explore.
 
 ### Run the Razor Network Docker Node {#run-the-razor-network-docker-node}
 
@@ -62,7 +62,7 @@ docker network create razor_network
 2. Start razor-go container
 
 ```
-docker run -d -it --entrypoint /bin/sh --network=razor_network --name razor-go -v "$(echo $HOME)"/.razor:/root/.razor razornetwork/razor-go:ab83868
+docker run -d -it --entrypoint /bin/sh --network=razor_network --name razor-go -v "$(echo $HOME)"/.razor:/root/.razor razornetwork/razor-go:7f77a9f
 ```
 
 This spins up a razor-go docker image. You can find all the images on the [Razor Network dockerhub](https://hub.docker.com/u/razornetwork).


### PR DESCRIPTION
- Updated latest release info to oracle node `v1.2.0`.
- Updated testnet info to europa testnet.
- Updated docs with changes from v1.2.0 release like updating default `logFileMaxAge` and `logFileMaxBackups` values.